### PR TITLE
Require building with `coq-itree.5.2.0`

### DIFF
--- a/opam
+++ b/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "ocamlfind"
   "coq" {>= "8.15"}
-  "coq-itree" {>= "5.0.0" & < "5.2"}
+  "coq-itree" {>= "5.2" & < "5.3"}
   "coq-paco" {>= "4.1.2"}
 ]
 build: [

--- a/opam
+++ b/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "ocamlfind"
   "coq" {>= "8.15"}
-  "coq-itree" {>= "5.0.0"}
+  "coq-itree" {>= "5.0.0" & < "5.2"}
   "coq-paco" {>= "4.1.2"}
 ]
 build: [

--- a/theories/Eq/Eqit.v
+++ b/theories/Eq/Eqit.v
@@ -8,7 +8,7 @@ From Paco Require Import paco.
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
      Eq.Paco2
      Basics.Monad

--- a/theories/Ref/AddSawCalls.v
+++ b/theories/Ref/AddSawCalls.v
@@ -1,6 +1,6 @@
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
  .
 From EnTree Require Import

--- a/theories/Ref/Concrete.v
+++ b/theories/Ref/Concrete.v
@@ -8,7 +8,7 @@ From Paco Require Import paco.
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
      Basics.Monad
      Eq.Paco2.

--- a/theories/Ref/EnTreeSpecCombinatorFacts.v
+++ b/theories/Ref/EnTreeSpecCombinatorFacts.v
@@ -6,7 +6,7 @@ From Coq Require Import
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
  .
 From EnTree Require Import

--- a/theories/Ref/EnTreeSpecDefinition.v
+++ b/theories/Ref/EnTreeSpecDefinition.v
@@ -8,7 +8,7 @@ From Paco Require Import paco.
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
      Basics.Monad
      Eq.Paco2.

--- a/theories/Ref/EnTreeSpecFacts.v
+++ b/theories/Ref/EnTreeSpecFacts.v
@@ -6,7 +6,7 @@ From Coq Require Import
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
  .
 From EnTree Require Import

--- a/theories/Ref/Example.v
+++ b/theories/Ref/Example.v
@@ -1,6 +1,6 @@
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
  .
 From ITree Require Import Basics.Monad.

--- a/theories/Ref/MRecSpec.v
+++ b/theories/Ref/MRecSpec.v
@@ -8,7 +8,7 @@ From Coq Require Import
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
  .
 From EnTree Require Import

--- a/theories/Ref/Padded.v
+++ b/theories/Ref/Padded.v
@@ -8,7 +8,7 @@ From Coq Require Import
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
  .
 

--- a/theories/Ref/TpEnc.v
+++ b/theories/Ref/TpEnc.v
@@ -10,7 +10,7 @@ From Paco Require Import paco.
 
 From ITree Require Import
      Basics.Basics
-     Basics.Tacs
+     Basics.Utils
      Basics.HeterogeneousRelations
      Eq.Paco2.
 


### PR DESCRIPTION
`coq-itree.5.2.0` renames `ITree.Basics.Tacs` to `ITree.Basics.Utils`, so this patch applies corresponding changes in `entree-specs` to accommodate it.

Fixes https://github.com/GaloisInc/entree-specs/issues/5.