### PR TITLE
Initial CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        ocaml: ["4.14.x"]
+        os: ["ubuntu-22.04"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml }}
+
+      - name: Add coq-released repo
+        shell: bash
+        run: opam repo add coq-released https://coq.inria.fr/opam/released
+
+      - name: Install dependencies
+        shell: bash
+        run: opam install . --deps-only --yes
+
+      - name: Build entree-specs
+        shell: bash
+        run: opam exec -- make -j

--- a/opam
+++ b/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/GaloisInc/entree-specs/issues"
 depends: [
   "ocaml"
   "ocamlfind"
-  "coq" {>= "8.15"}
+  "coq" {>= "8.15" & < "8.16"}
   "coq-itree" {>= "5.2" & < "5.3"}
   "coq-paco" {>= "4.1.2"}
 ]


### PR DESCRIPTION
This ports the Coq-based CI setup from `saw-script` over to `entree-specs`.

Fixes #8.