### PR TITLE
Require coq-paco >= 4.2.1 rather than 4.1.2

### DIFF
--- a/opam
+++ b/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind"
   "coq" {>= "8.15" & < "8.16"}
   "coq-itree" {>= "5.2" & < "5.3"}
-  "coq-paco" {>= "4.1.2"}
+  "coq-paco" {>= "4.2.1"}
 ]
 build: [
   [make]

--- a/theories/Ref/EnTreeSpecFacts.v
+++ b/theories/Ref/EnTreeSpecFacts.v
@@ -431,7 +431,7 @@ Proof.
       * constructor; auto. intros. eapply H0 in H2. right. pclearbot.
         eapply CIH; eauto with solve_padded.
         2 : apply REL.
-        (* these bits no longer needed 20241014 *)
+        (* these bits no longer needed with coq-paco 4.2.1 *)
         (* 2 : destruct H2; try contradiction; auto. *)
         inv Hpad1. inj_existT. subst. pstep.
         constructor. auto.


### PR DESCRIPTION
The change of coq-paco from 4.2.0 to 4.2.1 was what caused the previous build breakage.

Also update the comment about it to reflect this.